### PR TITLE
GHC 927 upgrade

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ init/id_rsa
 *~
 
 *.yaml.lock
+
+# Nix
+result
+.direnv

--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,2 @@
-packages: .
+packages:
+  .

--- a/euler-hs.cabal
+++ b/euler-hs.cabal
@@ -10,7 +10,7 @@ maintainer:    koz.ross@juspay.in
 copyright:     (C) Juspay Technologies Pvt Ltd 2019-2020
 category:      Euler
 build-type:    Simple
-tested-with:   GHC ==8.8.4
+tested-with:   GHC == 8.8.4
 
 source-repository head
   type:     git
@@ -20,13 +20,14 @@ common common-lang
   ghc-options:
     -Wall -Wcompat -Wincomplete-record-updates
     -Wincomplete-uni-patterns -Wredundant-constraints -Werror
+    "-Wwarn=ambiguous-fields"
     -fplugin=RecordDotPreprocessor
 
   build-depends:
     , base                     >=4.13   && <5
-    , record-dot-preprocessor  ^>=0.2.14
+    , record-dot-preprocessor
     , record-hasfield
-    , euler-events-hs          ^>=2.0.0
+    , euler-events-hs
 
   default-extensions:
     NoImplicitPrelude
@@ -99,10 +100,10 @@ library
     , QuickCheck
     , aeson
     , base64-bytestring
-    , beam-core             ^>=0.9.0.0
-    , beam-mysql            ^>=1.3.0.4
-    , beam-postgres         ^>=0.5.0.0
-    , beam-sqlite           ^>=0.5.0.0
+    , beam-core
+    , beam-mysql
+    , beam-postgres
+    , beam-sqlite
     , bytestring
     , case-insensitive
     , cereal
@@ -118,7 +119,7 @@ library
     , free
     , generic-deriving
     , generic-lens
-    , hedis                 ^>=0.12.8.1
+    , hedis
     , http-api-data
     , http-client
     , http-client-tls
@@ -126,7 +127,7 @@ library
     , http-types
     , juspay-extra          ^>=1.0.1.5
     , lrucaching
-    , mysql-haskell         ^>=0.8.4.2
+    , mysql-haskell
     , named
     , newtype-generics
     , nonempty-containers
@@ -140,11 +141,11 @@ library
     , reflection
     , resource-pool
     , scientific
-    , sequelize             ^>=1.1.1.0
+    , sequelize
     , servant
-    , servant-client        ^>=0.18.3
-    , servant-client-core   ^>=0.18.3
-    , servant-server        ^>=0.18.3
+    , servant-client
+    , servant-client-core
+    , servant-server
     , sqlite-simple
     , stm
     , store
@@ -215,11 +216,11 @@ test-suite language
     , quickcheck-instances
     , random
     , safe-exceptions
-    , sequelize             ^>=1.1.1.0
-    , servant               ^>=0.18.3
-    , servant-client        ^>=0.18.3
-    , servant-mock          ^>=0.8.7
-    , servant-server        ^>=0.18.3
+    , sequelize
+    , servant
+    , servant-client
+    , servant-mock
+    , servant-server
     , string-conversions
     , text
     , tls

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,997 @@
+{
+  "nodes": {
+    "beam-mysql": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1678429026,
+        "narHash": "sha256-Syxy6YKTO+ncCa7K/V/m/Pa+fFUsCdEFHHyBqIL1w2A=",
+        "owner": "juspay",
+        "repo": "beam-mysql",
+        "rev": "f8d029e6861ade3335a9f96b7be3b306d8208dd8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "juspay",
+        "repo": "beam-mysql",
+        "rev": "f8d029e6861ade3335a9f96b7be3b306d8208dd8",
+        "type": "github"
+      }
+    },
+    "cachix": {
+      "inputs": {
+        "devenv": "devenv",
+        "flake-compat": "flake-compat",
+        "hnix-store-core": "hnix-store-core",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1679144949,
+        "narHash": "sha256-xhLCsAkz5c+XIqQ4eGY9bSp3zBgCDCaHXZ2HLk8vqmE=",
+        "owner": "cachix",
+        "repo": "cachix",
+        "rev": "c8f0d787939c93cc686c2604f7d024e631e4a00d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "v1.3.3",
+        "repo": "cachix",
+        "type": "github"
+      }
+    },
+    "cachix-push": {
+      "inputs": {
+        "cachix": "cachix",
+        "devour-flake": "devour-flake"
+      },
+      "locked": {
+        "lastModified": 1682526722,
+        "narHash": "sha256-KT6KrzN61amTBoQjI1u+gXYYOaYYMLR4p7lcFLpwqy8=",
+        "owner": "juspay",
+        "repo": "cachix-push",
+        "rev": "18652f04b2bd28892f13571d6fd42853aaaf7862",
+        "type": "github"
+      },
+      "original": {
+        "owner": "juspay",
+        "repo": "cachix-push",
+        "type": "github"
+      }
+    },
+    "common": {
+      "inputs": {
+        "cachix-push": "cachix-push",
+        "flake-parts": "flake-parts",
+        "flake-root": "flake-root",
+        "haskell-flake": "haskell-flake",
+        "mission-control": "mission-control",
+        "nixpkgs": "nixpkgs_3",
+        "nixpkgs-140774-workaround": "nixpkgs-140774-workaround",
+        "nixpkgs-21_11": "nixpkgs-21_11",
+        "pre-commit-hooks-nix": "pre-commit-hooks-nix",
+        "process-compose-flake": "process-compose-flake",
+        "systems": "systems",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1686216929,
+        "narHash": "sha256-kfAONMom6qJavTV+Cz1JOkWYZDE4mLosdEol9N24Q3Y=",
+        "owner": "arjunkathuria",
+        "repo": "common",
+        "rev": "943e7aa036592d5374898ee32d7120e94d15bd23",
+        "type": "github"
+      },
+      "original": {
+        "owner": "arjunkathuria",
+        "ref": "Mobility-GHC927-Rebased",
+        "repo": "common",
+        "type": "github"
+      }
+    },
+    "devenv": {
+      "inputs": {
+        "flake-compat": [
+          "common",
+          "cachix-push",
+          "cachix",
+          "flake-compat"
+        ],
+        "nix": "nix",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
+      },
+      "locked": {
+        "lastModified": 1678184100,
+        "narHash": "sha256-6R0LmBiS2E6CApdqqFpY2IBXDAg2RQ2JHBkJOLMxXsY=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "b9e0ace80abd0ca5631ab5df7d6562ba9d8af50c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "devour-flake": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1682445319,
+        "narHash": "sha256-TTWt0MNxCjW6Rc0z8Li0X3O7wdAj1tr7tnPHxERb0p0=",
+        "owner": "srid",
+        "repo": "devour-flake",
+        "rev": "6cd32c62c4d7ef76f6e8534ae578a395af6cafce",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "devour-flake",
+        "type": "github"
+      }
+    },
+    "euler-events-hs": {
+      "inputs": {
+        "flake-parts": "flake-parts_2",
+        "haskell-flake": [
+          "common",
+          "haskell-flake"
+        ],
+        "nixpkgs": "nixpkgs_6",
+        "prometheus-haskell": "prometheus-haskell"
+      },
+      "locked": {
+        "lastModified": 1686292328,
+        "narHash": "sha256-xRLTjo9EXo1tDvChranINCu1wWHxHxF83eEu0EOJ6vA=",
+        "owner": "juspay",
+        "repo": "euler-events-hs",
+        "rev": "74ba3c12e94b37a0dc5a44c5a64d6d3da8cb0f67",
+        "type": "github"
+      },
+      "original": {
+        "owner": "juspay",
+        "repo": "euler-events-hs",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1677714448,
+        "narHash": "sha256-Hq8qLs8xFu28aDjytfxjdC96bZ6pds21Yy09mSC156I=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "dc531e3a9ce757041e1afaff8ee932725ca60002",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
+      "locked": {
+        "lastModified": 1683560683,
+        "narHash": "sha256-XAygPMN5Xnk/W2c1aW0jyEa6lfMDZWlQgiNtmHXytPc=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "006c75898cf814ef9497252b022e91c946ba8e17",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_3": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_3"
+      },
+      "locked": {
+        "lastModified": 1685662779,
+        "narHash": "sha256-cKDDciXGpMEjP1n6HlzKinN0H+oLmNpgeCTzYnsA2po=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "71fb97f0d875fd4de4994dfb849f2c75e17eb6c3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_4": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_4"
+      },
+      "locked": {
+        "lastModified": 1683560683,
+        "narHash": "sha256-XAygPMN5Xnk/W2c1aW0jyEa6lfMDZWlQgiNtmHXytPc=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "006c75898cf814ef9497252b022e91c946ba8e17",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-root": {
+      "locked": {
+        "lastModified": 1680210152,
+        "narHash": "sha256-VgFdqsu2i2oUcId9n8BFlRRc4GJHFvrmprdamcSZR1o=",
+        "owner": "srid",
+        "repo": "flake-root",
+        "rev": "6000244701c8ae8cf43263564095fd357d89c328",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "flake-root",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "common",
+          "cachix-push",
+          "cachix",
+          "devenv",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_2": {
+      "inputs": {
+        "nixpkgs": [
+          "common",
+          "pre-commit-hooks-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "haskell-flake": {
+      "locked": {
+        "lastModified": 1685469326,
+        "narHash": "sha256-esxJLsGexI/J6Fc32tJd2p3K5IOBZSCHgFvegjIpc+0=",
+        "owner": "srid",
+        "repo": "haskell-flake",
+        "rev": "996f5c2cdc67285c4990df378976f9dbf26f8401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "haskell-flake",
+        "type": "github"
+      }
+    },
+    "hedis": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1678429056,
+        "narHash": "sha256-Lw1w49kX9Uis7+BsjZGQpBBYTUL8YGZsIjZnM98J37c=",
+        "owner": "juspay",
+        "repo": "hedis",
+        "rev": "ac9e247803379f65b3a5fc99771259134ac01129",
+        "type": "github"
+      },
+      "original": {
+        "owner": "juspay",
+        "repo": "hedis",
+        "rev": "ac9e247803379f65b3a5fc99771259134ac01129",
+        "type": "github"
+      }
+    },
+    "hnix-store-core": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1672658037,
+        "narHash": "sha256-UOe+dY1dhCvdEKjPF1gNpfc4cNhZSKSbvu4yG+XVqbg=",
+        "owner": "haskell-nix",
+        "repo": "hnix-store",
+        "rev": "81700e6e7c53bbd7c6b2c4913b9481e5827af92f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell-nix",
+        "ref": "core-0.6.1.0",
+        "repo": "hnix-store",
+        "type": "github"
+      }
+    },
+    "juspay-extra": {
+      "inputs": {
+        "flake-parts": "flake-parts_4",
+        "haskell-flake": [
+          "common",
+          "haskell-flake"
+        ],
+        "nixpkgs": "nixpkgs_8"
+      },
+      "locked": {
+        "lastModified": 1686301075,
+        "narHash": "sha256-XYdV7kw/6nPZifwMfZmJc+XGq/V3m1o6sRPYNlvthvg=",
+        "owner": "juspay",
+        "repo": "euler-haskell-common",
+        "rev": "bc2b447b938a8e23d78b42e7287d72cfaab186e3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "juspay",
+        "repo": "euler-haskell-common",
+        "type": "github"
+      }
+    },
+    "lowdown-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1633514407,
+        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
+    "mission-control": {
+      "locked": {
+        "lastModified": 1680209746,
+        "narHash": "sha256-P8Q0mPdeo2SvKQUejvl7nOKO2ahIXb6aintYofCxcP8=",
+        "owner": "Platonic-Systems",
+        "repo": "mission-control",
+        "rev": "c1bd7344283d4006efb02cc660c5fd9befb73980",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Platonic-Systems",
+        "repo": "mission-control",
+        "type": "github"
+      }
+    },
+    "nix": {
+      "inputs": {
+        "lowdown-src": "lowdown-src",
+        "nixpkgs": [
+          "common",
+          "cachix-push",
+          "cachix",
+          "devenv",
+          "nixpkgs"
+        ],
+        "nixpkgs-regression": "nixpkgs-regression"
+      },
+      "locked": {
+        "lastModified": 1676545802,
+        "narHash": "sha256-EK4rZ+Hd5hsvXnzSzk2ikhStJnD63odF7SzsQ8CuSPU=",
+        "owner": "domenkozar",
+        "repo": "nix",
+        "rev": "7c91803598ffbcfe4a55c44ac6d49b2cf07a527f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "domenkozar",
+        "ref": "relaxed-flakes",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1677534593,
+        "narHash": "sha256-PuZSAHeq4/9pP/uYH1FcagQ3nLm/DrDrvKi/xC9glvw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3ad64d9e2d5bf80c877286102355b1625891ae9a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-140774-workaround": {
+      "locked": {
+        "lastModified": 1678736468,
+        "narHash": "sha256-l5BdAeq9ymhUox0sTqeKibx9zkreWbIllwTvCamJLE8=",
+        "owner": "srid",
+        "repo": "nixpkgs-140774-workaround",
+        "rev": "335c2052970106d8f09f6f7f522f29d6ccaa2416",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "nixpkgs-140774-workaround",
+        "type": "github"
+      }
+    },
+    "nixpkgs-21_11": {
+      "locked": {
+        "lastModified": 1659446231,
+        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-21.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1677407201,
+        "narHash": "sha256-3blwdI9o1BAprkvlByHvtEm5HAIRn/XPjtcfiunpY7s=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7f5639fa3b68054ca0b062866dc62b22c3f11505",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_2": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1682879489,
+        "narHash": "sha256-sASwo8gBt7JDnOOstnps90K1wxmVfyhsTPPNTGBPjjg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "da45bf6ec7bbcc5d1e14d3795c025199f28e0de0",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_3": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1685564631,
+        "narHash": "sha256-8ywr3AkblY4++3lIVxmrWZFzac7+f32ZEhH/A8pNscI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4f53efe34b3a8877ac923b9350c874e3dcd5dc0a",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_4": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1682879489,
+        "narHash": "sha256-sASwo8gBt7JDnOOstnps90K1wxmVfyhsTPPNTGBPjjg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "da45bf6ec7bbcc5d1e14d3795c025199f28e0de0",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1673800717,
+        "narHash": "sha256-SFHraUqLSu5cC6IxTprex/nTsI81ZQAtDvlBvGDWfnA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2f9fd351ec37f5d479556cd48be4ca340da59b8f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable_2": {
+      "locked": {
+        "lastModified": 1678872516,
+        "narHash": "sha256-/E1YwtMtFAu2KUQKV/1+KFuReYPANM2Rzehk84VxVoc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9b8e5abb18324c7fe9f07cb100c3cd4a29cda8b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1678072060,
+        "narHash": "sha256-6a9Tbjhir5HxDx4uw0u6Z+LHUfYf7tsT9QxF9FN/32w=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "47c003416297e4d59a5e3e7a8b15cdbdf5110560",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1681358109,
+        "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "96ba1c52e54e74c3197f4d43026b3f3d92e83ff9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1681303793,
+        "narHash": "sha256-JEdQHsYuCfRL2PICHlOiH/2ue3DwoxUX7DJ6zZxZXFk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fe2ecaf706a5907b5e54d979fbde4924d84b65fc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1680945546,
+        "narHash": "sha256-8FuaH5t/aVi/pR1XxnF0qi4WwMYC+YxlfdsA0V+TEuQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d9f759f2ea8d265d974a6e1259bd510ac5844c5d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_6": {
+      "locked": {
+        "lastModified": 1684879512,
+        "narHash": "sha256-BoAOf19Dshtfu6BDPznrKO97oeCkXlYfa1Hyt0Qv8VU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e6e049b7a24decd1f0caee8b035913795697c699",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_7": {
+      "locked": {
+        "lastModified": 1686089707,
+        "narHash": "sha256-LTNlJcru2qJ0XhlhG9Acp5KyjB774Pza3tRH0pKIb3o=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "af21c31b2a1ec5d361ed8050edd0303c31306397",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_8": {
+      "locked": {
+        "lastModified": 1684879512,
+        "narHash": "sha256-BoAOf19Dshtfu6BDPznrKO97oeCkXlYfa1Hyt0Qv8VU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e6e049b7a24decd1f0caee8b035913795697c699",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_9": {
+      "locked": {
+        "lastModified": 1684973047,
+        "narHash": "sha256-ZLnSr35L6C49pCZS9fZCCqkIKNAeQzykov2QfosNG9w=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "21eb6c6ba74dcbe3ea5926ee46287300fb066630",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": [
+          "common",
+          "cachix-push",
+          "cachix",
+          "devenv",
+          "flake-compat"
+        ],
+        "flake-utils": "flake-utils",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "common",
+          "cachix-push",
+          "cachix",
+          "devenv",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1677160285,
+        "narHash": "sha256-tBzpCjMP+P3Y3nKLYvdBkXBg3KvTMo3gvi8tLQaqXVY=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "2bd861ab81469428d9c823ef72c4bb08372dd2c4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks-nix": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils_2",
+        "gitignore": "gitignore_2",
+        "nixpkgs": "nixpkgs_4",
+        "nixpkgs-stable": "nixpkgs-stable_2"
+      },
+      "locked": {
+        "lastModified": 1682596858,
+        "narHash": "sha256-Hf9XVpqaGqe/4oDGr30W8HlsWvJXtMsEPHDqHZA6dDg=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "fb58866e20af98779017134319b5663b8215d912",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "process-compose-flake": {
+      "locked": {
+        "lastModified": 1680797953,
+        "narHash": "sha256-lFYbfId1IX6jh/wUf+gt3LyvE9HblS4hcBQcougSzX0=",
+        "owner": "Platonic-Systems",
+        "repo": "process-compose-flake",
+        "rev": "aee1b8d126a5efe5945513eb2fb343f3d68dca4b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Platonic-Systems",
+        "repo": "process-compose-flake",
+        "type": "github"
+      }
+    },
+    "prometheus-haskell": {
+      "inputs": {
+        "flake-parts": "flake-parts_3",
+        "haskell-flake": [
+          "euler-events-hs",
+          "haskell-flake"
+        ],
+        "nixpkgs": "nixpkgs_7"
+      },
+      "locked": {
+        "lastModified": 1684305829,
+        "narHash": "sha256-MrM4ZFZuu0e6aVd7ixw5ZNhD4Vcrc6lUL+d1NO7mJ38=",
+        "owner": "juspay",
+        "repo": "prometheus-haskell",
+        "rev": "1104a429745c45f333508c7aa2cd7d6f94b76755",
+        "type": "github"
+      },
+      "original": {
+        "owner": "juspay",
+        "ref": "more-proc-metrics",
+        "repo": "prometheus-haskell",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "beam-mysql": "beam-mysql",
+        "common": "common",
+        "euler-events-hs": "euler-events-hs",
+        "flake-parts": [
+          "common",
+          "flake-parts"
+        ],
+        "haskell-flake": [
+          "common",
+          "haskell-flake"
+        ],
+        "hedis": "hedis",
+        "juspay-extra": "juspay-extra",
+        "nixpkgs": "nixpkgs_9",
+        "sequelize": "sequelize",
+        "servant-mock": "servant-mock",
+        "tinylog": "tinylog",
+        "word24": "word24"
+      }
+    },
+    "sequelize": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1678441454,
+        "narHash": "sha256-TIQVqrP7qbNKQ54r1dky5MULlLV8TZFNl2/IrXPYYk8=",
+        "owner": "juspay",
+        "repo": "haskell-sequelize",
+        "rev": "31948e744e431320492031cfddd01e7a9896631d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "juspay",
+        "repo": "haskell-sequelize",
+        "rev": "31948e744e431320492031cfddd01e7a9896631d",
+        "type": "github"
+      }
+    },
+    "servant-mock": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1672315259,
+        "narHash": "sha256-J7Lsa3zI1Z05Gtf5m1x4yRE5vRnuhZLWeUShtrhsPbk=",
+        "owner": "arjunkathuria",
+        "repo": "servant-mock",
+        "rev": "17e90cb831820a30b3215d4f164cf8268607891e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "arjunkathuria",
+        "repo": "servant-mock",
+        "rev": "17e90cb831820a30b3215d4f164cf8268607891e",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "tinylog": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1669960992,
+        "narHash": "sha256-o0WEbygbbfIYPonyY6ui1HcbaJcFdngjBhnjWbe65zs=",
+        "rev": "08d3b6066cd2f883e183b7cd01809d1711092d33",
+        "revCount": 78,
+        "type": "git",
+        "url": "https://gitlab.com/arjunkathuria/tinylog.git"
+      },
+      "original": {
+        "rev": "08d3b6066cd2f883e183b7cd01809d1711092d33",
+        "type": "git",
+        "url": "https://gitlab.com/arjunkathuria/tinylog.git"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_5"
+      },
+      "locked": {
+        "lastModified": 1682536470,
+        "narHash": "sha256-dGR2FRxWswpQCHdivejB3uiLZPktnT3DYp6ZkybR/SE=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "6d8bea2820630576ad8c3a3bde2c95c38bcc471f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "word24": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1647587255,
+        "narHash": "sha256-S37S10sJ45BulvpqJzlhX/J4hY7cW5jLM9nP4xAftac=",
+        "owner": "winterland1989",
+        "repo": "word24",
+        "rev": "445f791e35ddc8098f05879dbcd07c41b115cb39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "winterland1989",
+        "repo": "word24",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,91 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    # update common after changes mainlined - https://github.com/nammayatri/common/pull/13
+    common.url = "github:arjunkathuria/common/Mobility-GHC927-Rebased";
+    flake-parts.follows = "common/flake-parts";
+    haskell-flake.follows = "common/haskell-flake";
+
+    # Haskell dependencies
+    sequelize.url = "github:juspay/haskell-sequelize?rev=31948e744e431320492031cfddd01e7a9896631d";
+    sequelize.flake = false;
+    beam-mysql.url = "github:juspay/beam-mysql?rev=f8d029e6861ade3335a9f96b7be3b306d8208dd8";
+    beam-mysql.flake = false;
+    hedis.url = "github:juspay/hedis/ac9e247803379f65b3a5fc99771259134ac01129";
+    hedis.flake = false;
+
+    euler-events-hs.url = "github:juspay/euler-events-hs";
+    euler-events-hs.inputs.haskell-flake.follows = "common/haskell-flake";
+
+    juspay-extra.url = "github:juspay/euler-haskell-common";
+    juspay-extra.inputs.haskell-flake.follows = "common/haskell-flake";
+
+    word24.url = "github:winterland1989/word24";
+    word24.flake = false;
+
+    servant-mock.url = "github:arjunkathuria/servant-mock?rev=17e90cb831820a30b3215d4f164cf8268607891e";
+    servant-mock.flake = false;
+
+    tinylog.url = "git+https://gitlab.com/arjunkathuria/tinylog.git?rev=08d3b6066cd2f883e183b7cd01809d1711092d33";
+    tinylog.flake = false;
+  };
+
+  outputs = inputs@{ self, nixpkgs, flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } ({ withSystem, ... }: {
+      systems = nixpkgs.lib.systems.flakeExposed;
+      imports = [
+        inputs.common.flakeModules.ghc927
+        inputs.haskell-flake.flakeModule
+      ];
+      perSystem = { self', pkgs, lib, config, ... }: {
+        packages.default = self'.packages.euler-hs;
+        haskellProjects.default = {
+          projectFlakeName = "euler-hs";
+
+          imports = [
+            inputs.euler-events-hs.haskellFlakeProjectModules.output
+            inputs.juspay-extra.haskellFlakeProjectModules.output
+          ];
+
+          basePackages = config.haskellProjects.ghc927.outputs.finalPackages;
+
+          packages = {
+            beam-mysql.source = inputs.beam-mysql;
+            hedis.source = inputs.hedis;
+            sequelize.source = inputs.sequelize;
+            word24.source = inputs.word24;
+            servant-mock.source = inputs.servant-mock;
+            tinylog.source = inputs.tinylog;
+          };
+
+          settings = {
+            hedis = {
+              check = false;
+            };
+
+            euler-events-hs = {
+              jailbreak = true;
+              check = false;
+            };
+
+            prometheus-client = {
+              check = false;
+            };
+
+            prometheus-proc = {
+              jailbreak = true;
+            };
+
+            word24 = {
+              check = false;
+            };
+
+            servant-mock = {
+              check = false;
+              jailbreak=true;
+            };
+          };
+        };
+      };
+    });
+}

--- a/src/EulerHS/Extra/EulerDB.hs
+++ b/src/EulerHS/Extra/EulerDB.hs
@@ -18,7 +18,7 @@ module EulerHS.Extra.EulerDB (
 
 import           EulerHS.Language (MonadFlow, SqlDB, getOption, logErrorT,
                                    throwException, withDB, withDBTransaction)
-import           EulerHS.Prelude hiding (getOption)
+import           EulerHS.Prelude
 import           EulerHS.Types (DBConfig, OptionEntity)
 
 import           Database.Beam.MySQL (MySQLM)

--- a/src/EulerHS/Framework/Language.hs
+++ b/src/EulerHS/Framework/Language.hs
@@ -94,7 +94,7 @@ import           EulerHS.Logger.Language (Logger, logMessage')
 import           EulerHS.Logger.Types (LogLevel (Debug, Error, Info, Warning),
                                        Message (Message))
 import           EulerHS.Options (OptionEntity, mkOptionKey)
-import           EulerHS.Prelude hiding (getOption, throwM)
+import           EulerHS.Prelude hiding (throwM)
 import qualified EulerHS.PubSub.Language as PSL
 import           EulerHS.SqlDB.Language (SqlDB)
 import           EulerHS.SqlDB.Types (BeamRunner, BeamRuntime, DBConfig,

--- a/src/EulerHS/Framework/Language.hs
+++ b/src/EulerHS/Framework/Language.hs
@@ -1644,7 +1644,7 @@ instance OptionEntity DBMetricCfg DBAndRedisMetricHandler
 ---------------------------------------------------------
 
 isDBMetricEnabled :: Bool
-isDBMetricEnabled = fromMaybe False $ readMaybe =<< Conf.lookupEnvT "DB_METRIC_ENABLED"
+isDBMetricEnabled = fromMaybe False $ readMaybe =<< (Conf.lookupEnvT "DB_METRIC_ENABLED" :: Maybe Text)
 
 ---------------------------------------------------------
 

--- a/src/EulerHS/KVDB/Types.hs
+++ b/src/EulerHS/KVDB/Types.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE RecordWildCards    #-}
+{-# OPTIONS_GHC -Wwarn=missing-fields #-}
 
 module EulerHS.KVDB.Types
   (

--- a/src/EulerHS/Prelude.hs
+++ b/src/EulerHS/Prelude.hs
@@ -33,7 +33,7 @@ import           Data.Serialize as X (Serialize)
 import           Fmt as X ((+|), (+||), (|+), (||+))
 import           GHC.Base as X (until)
 import           Universum (catchAny)
-import           Universum as X hiding (All, Option, Set, Type, catchAny, head,
+import           Universum as X hiding (All, Set, Type, catchAny, head,
                                  init, last, set, tail, trace)
 
 -- Lift for Church encoded Free

--- a/src/EulerHS/SqlDB/Types.hs
+++ b/src/EulerHS/SqlDB/Types.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE RecordWildCards        #-}
 {-# LANGUAGE ScopedTypeVariables    #-}
+{-# OPTIONS_GHC -Wwarn=incomplete-patterns #-}
 
 module EulerHS.SqlDB.Types
   (

--- a/src/EulerHS/SqlDB/Types.hs
+++ b/src/EulerHS/SqlDB/Types.hs
@@ -58,6 +58,7 @@ import qualified Database.Beam.Sqlite.Connection as SQLite
 import qualified Database.MySQL.Base as MySQL
 import qualified Database.PostgreSQL.Simple as PGS
 import qualified Database.SQLite.Simple as SQLite
+import qualified Data.Text as T
 import           EulerHS.Prelude
 import           EulerHS.SqlDB.MySQL (MySQLConfig (..), createMySQLConn)
 import           EulerHS.SqlDB.Postgres (PostgresConfig (..),
@@ -119,12 +120,12 @@ class BeamRunner beM where
 
 instance BeamRunner BS.SqliteM where
   getBeamDebugRunner (NativeSQLiteConn conn) beM =
-    \logger -> SQLite.runBeamSqliteDebug logger conn beM
+    \logger -> SQLite.runBeamSqliteDebug (logger . T.pack) conn beM
   getBeamDebugRunner _ _ = \_ -> error "Not a SQLite connection"
 
 instance BeamRunner BP.Pg where
   getBeamDebugRunner (NativePGConn conn) beM =
-    \logger -> BP.runBeamPostgresDebug logger conn beM
+    \logger -> BP.runBeamPostgresDebug (logger . T.pack) conn beM
   getBeamDebugRunner _ _ = \_ -> error "Not a Postgres connection"
 
 instance BeamRunner BM.MySQLM where

--- a/test/extra/Options.hs
+++ b/test/extra/Options.hs
@@ -196,7 +196,7 @@ fruit :: Plant
 fruit = Fruit $ Apple 12 (Just "green")
 
 enc_plant :: BSL.ByteString
-enc_plant = "{\"tag\":\"Fruit\",\"contents\":{\"weight\":12,\"colour\":\"green\"}}"
+enc_plant = "{\"contents\":{\"colour\":\"green\",\"weight\":12},\"tag\":\"Fruit\"}"
 
 data PlantUnTag
   = FruitU Apple
@@ -212,7 +212,7 @@ berry :: PlantUnTag
 berry = BerryU $ Strawberry 2 (Just "red")
 
 enc_plantUntag :: BSL.ByteString
-enc_plantUntag = "{\"weight\":2,\"colour\":\"red\"}"
+enc_plantUntag = "{\"colour\":\"red\",\"weight\":2}"
 
 -------------------------------------------------------------------------------
 -- stripLensPrefixOptions
@@ -229,7 +229,7 @@ cat :: Cat
 cat = Cat "Kita" (Just "grey")
 
 enc_cat :: BSL.ByteString
-enc_cat = "{\"cName\":\"Kita\",\"cColour\":\"grey\"}"
+enc_cat = "{\"cColour\":\"grey\",\"cName\":\"Kita\"}"
 
 data Dog = Dog
   { cName :: Text
@@ -280,7 +280,7 @@ cow :: Cow
 cow = Cow "Mu" (Just "white-nd-black")
 
 enc_cow :: BSL.ByteString
-enc_cow = "{\"cName\":\"Mu\",\"cColour\":\"white-nd-black\"}"
+enc_cow = "{\"cColour\":\"white-nd-black\",\"cName\":\"Mu\"}"
 
 data Wolf = Wolf
   { cName :: Text

--- a/test/language/DBSetup.hs
+++ b/test/language/DBSetup.hs
@@ -19,14 +19,14 @@ import           Sequelize
 -- Prepare custom types for tests
 
 data UserT f = User
-    { _userGUID  :: B.C f Int
+    { _userGUID  :: B.C f Int64
     , _firstName :: B.C f Text
     , _lastName  :: B.C f Text
     } deriving (Generic, B.Beamable)
 
 instance B.Table UserT where
   data PrimaryKey UserT f =
-    UserId (B.C f Int) deriving (Generic, B.Beamable)
+    UserId (B.C f Int64) deriving (Generic, B.Beamable)
   primaryKey = UserId . _userGUID
 
 instance ModelMeta UserT where

--- a/test/language/FlowSpec.hs
+++ b/test/language/FlowSpec.hs
@@ -21,7 +21,7 @@ import           Test.Hspec (Spec, around, around_, describe, it, shouldBe,
 
 import           EulerHS.Interpreters (runFlow)
 import           EulerHS.Language as L
-import           EulerHS.Prelude hiding (get, getOption)
+import           EulerHS.Prelude hiding (get)
 import           EulerHS.Runtime (createLoggerRuntime, withFlowRuntime)
 import           EulerHS.TestData.Types (NTTestKeyWithIntPayload (NTTestKeyWithIntPayload),
                                          NTTestKeyWithIntPayloadAnotherEnc (NTTestKeyWithIntPayloadAnotherEnc),

--- a/test/language/HttpAPISpec.hs
+++ b/test/language/HttpAPISpec.hs
@@ -4,7 +4,7 @@ module HttpAPISpec (spec) where
 
 --import           EulerHS.Interpreters (runFlow)
 --import           EulerHS.Language
-import           EulerHS.Prelude hiding (get, getOption)
+import           EulerHS.Prelude hiding (get)
 --import           EulerHS.Runtime (createLoggerRuntime, withFlowRuntime)
 import           Test.Hspec (Spec, describe, it, shouldBe)
 import qualified EulerHS.Types as T

--- a/test/language/Scenario1.hs
+++ b/test/language/Scenario1.hs
@@ -8,7 +8,7 @@ module Scenario1
 import           Client (User (User), getUser, port, userGUID)
 import           Data.Text (pack)
 import           EulerHS.Language
-import           EulerHS.Prelude hiding (getOption, pack)
+import           EulerHS.Prelude hiding (pack)
 import           EulerHS.TestData.Types
 import           Servant.Client (BaseUrl (..), Scheme (..))
 

--- a/testDB/SQLDB/TestData/Scenarios/MySQL.hs
+++ b/testDB/SQLDB/TestData/Scenarios/MySQL.hs
@@ -109,7 +109,7 @@ selectUnknownDbScript dbcfg = do
           $ B.filter_ predicate
           $ B.all_ (_users eulerDb)
 
-selectRowDbScript :: Int -> T.DBConfig BM.MySQLM -> L.Flow (T.DBResult (Maybe User))
+selectRowDbScript :: Int64 -> T.DBConfig BM.MySQLM -> L.Flow (T.DBResult (Maybe User))
 selectRowDbScript userId dbcfg = do
     econn <- L.getSqlDBConnection dbcfg
 

--- a/testDB/SQLDB/TestData/Types.hs
+++ b/testDB/SQLDB/TestData/Types.hs
@@ -13,14 +13,14 @@ import qualified EulerHS.Types as T
 -- sqlite3 db
 -- CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, first_name VARCHAR NOT NULL, last_name VARCHAR NOT NULL);
 data UserT f = User
-    { _userId        :: B.C f Int
+    { _userId        :: B.C f Int64
     , _userFirstName :: B.C f Text
     , _userLastName  :: B.C f Text
     } deriving (Generic, B.Beamable)
 
 instance B.Table UserT where
   data PrimaryKey UserT f =
-    UserId (B.C f Int) deriving (Generic, B.Beamable)
+    UserId (B.C f Int64) deriving (Generic, B.Beamable)
   primaryKey = UserId . _userId
 
 type User = UserT Identity
@@ -43,7 +43,7 @@ eulerDb = B.defaultDbSettings
 
 data SqliteSequenceT f = SqliteSequence
     { _name :: B.C f Text
-    , _seq  :: B.C f Int
+    , _seq  :: B.C f Int64
     } deriving (Generic, B.Beamable)
 
 instance B.Table SqliteSequenceT where
@@ -73,7 +73,7 @@ susers =
 mkUser ::
   (BeamSqlBackend be,
     B.SqlValable (B.Columnar f Text),
-    B.Columnar f Int ~ B.QGenExpr ctxt be s a,
+    B.Columnar f Int64 ~ B.QGenExpr ctxt be s a,
     B.HaskellLiteralForQExpr (B.Columnar f Text) ~ Text) =>
     SimpleUser ->
     UserT f

--- a/testDB/SQLDB/Tests/QueryExamplesSpec.hs
+++ b/testDB/SQLDB/Tests/QueryExamplesSpec.hs
@@ -66,19 +66,19 @@ td3 = TimeOfDay
   }
 
 data MemberT f = Member
-    { memberId      :: B.C f Int
+    { memberId      :: B.C f Int64
     , surName       :: B.C f Text
     , firstName     :: B.C f Text
     , address       :: B.C f Text
-    , zipCode       :: B.C f Int
+    , zipCode       :: B.C f Int64
     , telephone     :: B.C f Text
-    , recommendedBy :: B.C f (Maybe Int)
+    , recommendedBy :: B.C f (Maybe Int64)
     , joinDate      :: B.C f LocalTime
     } deriving (Generic, B.Beamable)
 
 instance B.Table MemberT where
   data PrimaryKey MemberT f =
-    MemberId (B.C f Int) deriving (Generic, B.Beamable)
+    MemberId (B.C f Int64) deriving (Generic, B.Beamable)
   primaryKey = MemberId . memberId
 
 type Member = MemberT Identity
@@ -111,7 +111,7 @@ membersEMod = B.modifyTableFields
     }
 
 data FacilityT f = Facility
-    { facilityId         :: B.C f Int
+    { facilityId         :: B.C f Int64
     , name               :: B.C f Text
     , memberCost         :: B.C f Double
     , guestCost          :: B.C f Double
@@ -121,7 +121,7 @@ data FacilityT f = Facility
 
 instance B.Table FacilityT where
   data PrimaryKey FacilityT f =
-    FacrId (B.C f Int) deriving (Generic, B.Beamable)
+    FacrId (B.C f Int64) deriving (Generic, B.Beamable)
   primaryKey = FacrId . facilityId
 
 type Facility = FacilityT Identity

--- a/testDB/SQLDB/Tests/QueryExamplesSpec.hs
+++ b/testDB/SQLDB/Tests/QueryExamplesSpec.hs
@@ -11,7 +11,7 @@ import           Database.Beam.Sqlite (SqliteM)
 import           EulerHS.Interpreters
 import           EulerHS.Language
 import qualified EulerHS.Language as L
-import           EulerHS.Prelude hiding (getOption)
+import           EulerHS.Prelude
 import           EulerHS.Runtime (withFlowRuntime)
 import qualified EulerHS.Runtime as R
 import           EulerHS.Types (_isAsync, _logFilePath, _logToFile,


### PR DESCRIPTION
This PR enables and upgrades Euler-hs repo to be able build with newer GHC 9.2.7, using nix.

Key changes include

1. Use updated dependencies (which were inturn patched to be able to build with GHC 9.2.7)
2. Code changes in this project, needed to build after breaking changes and major library version upgrades for eg. aeson 1.x -> aeson 2.x and other.
3. Nix flake build setup, compatible with updated haskell-flake 0.4.0 syntax.
4. Patched tests code to be able to build with GHC 9.2.7
5. Adds some basic QoL improvements like an envrc file to make it work with direnv, updated gitignore, new cabal.project file etc

and more.