### PR TITLE
Mobility GHC927 Upgrade Final

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ init/id_rsa
 *~
 
 *.yaml.lock
+
+# Nix
+result
+.direnv

--- a/euler-hs.cabal
+++ b/euler-hs.cabal
@@ -21,6 +21,7 @@ common common-lang
     -Wall -Wcompat -Wincomplete-record-updates
     -Wincomplete-uni-patterns -Wredundant-constraints
     -fplugin=RecordDotPreprocessor
+    "-Wwarn=ambiguous-fields"
 
   build-depends:
     , base                     

--- a/flake.lock
+++ b/flake.lock
@@ -148,16 +148,15 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1698621849,
-        "narHash": "sha256-/pd2eJNUUcEP6iKXyyrBJaqhQ79D4a+D98HJ3mNqjQ8=",
-        "owner": "arjunkathuria",
+        "lastModified": 1699950488,
+        "narHash": "sha256-llyrSKHNFL1FptFykCelRjitl3x0b4JsSkQQyCKVZhU=",
+        "owner": "nammayatri",
         "repo": "common",
-        "rev": "20580e2aa81b9adc45e6006472a8d73d062d8ff6",
+        "rev": "0ae95ce0df4a0c6be221fdbd946f35e54e97ccf5",
         "type": "github"
       },
       "original": {
-        "owner": "arjunkathuria",
-        "ref": "Mobility-GHC927-rebased-04",
+        "owner": "nammayatri",
         "repo": "common",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,36 +1,77 @@
 {
   "nodes": {
     "beam": {
-      "flake": false,
+      "inputs": {
+        "flake-parts": "flake-parts_5",
+        "haskell-flake": [
+          "sequelize",
+          "beam-mysql",
+          "haskell-flake"
+        ],
+        "nixpkgs": [
+          "sequelize",
+          "beam-mysql",
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1676828369,
-        "narHash": "sha256-qCTCvYbrVJBr6dAWsvjt9cFiMiUDoh9U6L8Ykl3xtmU=",
-        "owner": "srid",
+        "lastModified": 1693307537,
+        "narHash": "sha256-BIq3ZjZQWQ0w3zWA19zGBggiVVfnOzR5d4b7De0oVZY=",
+        "owner": "arjunkathuria",
         "repo": "beam",
-        "rev": "d7031dcffafcab55850c9b3fd2561d3e279f1965",
+        "rev": "06bcc50997fdcfb87125bed252e888e5dd1e6d9c",
         "type": "github"
       },
       "original": {
-        "owner": "srid",
-        "ref": "ghc810",
+        "owner": "arjunkathuria",
+        "ref": "GHC-927-Upgrade",
         "repo": "beam",
         "type": "github"
       }
     },
     "beam-mysql": {
+      "inputs": {
+        "beam": "beam",
+        "bytestring-lexing": "bytestring-lexing",
+        "flake-parts": "flake-parts_6",
+        "haskell-flake": [
+          "sequelize",
+          "haskell-flake"
+        ],
+        "mysql-haskell": "mysql-haskell",
+        "nixpkgs": [
+          "sequelize",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1693308989,
+        "narHash": "sha256-3qyg/Uj3A+MTS494VH2lTBtOz9uptgm+V1M1bPFxTX0=",
+        "owner": "arjunkathuria",
+        "repo": "beam-mysql",
+        "rev": "2ef13d8ecdcd0959b8604b3106b2013baf2ad272",
+        "type": "github"
+      },
+      "original": {
+        "owner": "arjunkathuria",
+        "ref": "GHC-927",
+        "repo": "beam-mysql",
+        "type": "github"
+      }
+    },
+    "bytestring-lexing": {
       "flake": false,
       "locked": {
-        "lastModified": 1675165348,
-        "narHash": "sha256-sFOtfvAeFwIaMpMK8vD5usE71/jTHwDCdbf++h4jOqQ=",
+        "lastModified": 1596188445,
+        "narHash": "sha256-n/5kFb5msE8NPQZf6bsm8MQh0RGDoOx6EJXoji6FPMs=",
         "owner": "juspay",
-        "repo": "beam-mysql",
-        "rev": "b4dbc91276f6a8b5356633492f89bdac34ccd9a1",
+        "repo": "bytestring-lexing",
+        "rev": "0a46db1139011736687cb50bbd3877d223bcb737",
         "type": "github"
       },
       "original": {
         "owner": "juspay",
-        "repo": "beam-mysql",
-        "rev": "b4dbc91276f6a8b5356633492f89bdac34ccd9a1",
+        "repo": "bytestring-lexing",
         "type": "github"
       }
     },
@@ -78,17 +119,16 @@
     "cereal": {
       "flake": false,
       "locked": {
-        "lastModified": 1668616659,
-        "narHash": "sha256-FkwxTJzY4A2CaGnQ+YBdEKZr+apEBK8Awcxrfp4uIvE=",
+        "lastModified": 1696234101,
+        "narHash": "sha256-dDUIny/9kZ0Bx/r/IPa9XRDcNT10XweR1uHqKx1CbAk=",
         "owner": "juspay",
         "repo": "cereal",
-        "rev": "213f145ccbd99e630ee832d2f5b22894c810d3cc",
+        "rev": "ee7fc69f499e86b8274906ba183b60f4f08457a6",
         "type": "github"
       },
       "original": {
         "owner": "juspay",
         "repo": "cereal",
-        "rev": "213f145ccbd99e630ee832d2f5b22894c810d3cc",
         "type": "github"
       }
     },
@@ -108,15 +148,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1687365764,
-        "narHash": "sha256-T67Dr9TvZYfXEOuFPfdDnNKTc1Kqy6xyhFjXEXHu1Dc=",
-        "owner": "nammayatri",
+        "lastModified": 1698621849,
+        "narHash": "sha256-/pd2eJNUUcEP6iKXyyrBJaqhQ79D4a+D98HJ3mNqjQ8=",
+        "owner": "arjunkathuria",
         "repo": "common",
-        "rev": "5f16f3ebf64a4523eb8c1b20dadcb65cef5146ab",
+        "rev": "20580e2aa81b9adc45e6006472a8d73d062d8ff6",
         "type": "github"
       },
       "original": {
-        "owner": "nammayatri",
+        "owner": "arjunkathuria",
+        "ref": "Mobility-GHC927-rebased-04",
         "repo": "common",
         "type": "github"
       }
@@ -167,7 +208,6 @@
       "inputs": {
         "flake-parts": "flake-parts_2",
         "haskell-flake": [
-          "common",
           "haskell-flake"
         ],
         "nixpkgs": "nixpkgs_6",
@@ -284,6 +324,60 @@
         "owner": "hercules-ci",
         "repo": "flake-parts",
         "rev": "006c75898cf814ef9497252b022e91c946ba8e17",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_5": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_5"
+      },
+      "locked": {
+        "lastModified": 1690933134,
+        "narHash": "sha256-ab989mN63fQZBFrkk4Q8bYxQCktuHmBIBqUG1jl6/FQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "59cf3f1447cfc75087e7273b04b31e689a8599fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_6": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_6"
+      },
+      "locked": {
+        "lastModified": 1690933134,
+        "narHash": "sha256-ab989mN63fQZBFrkk4Q8bYxQCktuHmBIBqUG1jl6/FQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "59cf3f1447cfc75087e7273b04b31e689a8599fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_7": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_7"
+      },
+      "locked": {
+        "lastModified": 1690933134,
+        "narHash": "sha256-ab989mN63fQZBFrkk4Q8bYxQCktuHmBIBqUG1jl6/FQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "59cf3f1447cfc75087e7273b04b31e689a8599fb",
         "type": "github"
       },
       "original": {
@@ -436,7 +530,6 @@
       "inputs": {
         "flake-parts": "flake-parts_4",
         "haskell-flake": [
-          "common",
           "haskell-flake"
         ],
         "nixpkgs": "nixpkgs_8"
@@ -487,19 +580,32 @@
       }
     },
     "mysql-haskell": {
-      "flake": false,
+      "inputs": {
+        "flake-parts": "flake-parts_7",
+        "haskell-flake": [
+          "sequelize",
+          "beam-mysql",
+          "haskell-flake"
+        ],
+        "nixpkgs": [
+          "sequelize",
+          "beam-mysql",
+          "nixpkgs"
+        ],
+        "word24": "word24"
+      },
       "locked": {
-        "lastModified": 1594736429,
-        "narHash": "sha256-mxIaWkfyrF0FhEK2WLhyPiIiGjKlG2kUn78E+GDAGAw=",
-        "owner": "juspay",
+        "lastModified": 1692868544,
+        "narHash": "sha256-UY9HRnqWXv5Ud6pfBa/fPNwjauDYpgzJoLcQb4NuH7I=",
+        "owner": "arjunkathuria",
         "repo": "mysql-haskell",
-        "rev": "788022d65538db422b02ecc0be138b862d2e5cee",
+        "rev": "2f4861667d19e84474700f32922c97af94f5dfc4",
         "type": "github"
       },
       "original": {
-        "owner": "juspay",
+        "owner": "arjunkathuria",
+        "ref": "GHC-927",
         "repo": "mysql-haskell",
-        "rev": "788022d65538db422b02ecc0be138b862d2e5cee",
         "type": "github"
       }
     },
@@ -649,6 +755,60 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib_5": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1690881714,
+        "narHash": "sha256-h/nXluEqdiQHs1oSgkOOWF+j8gcJMWhwnZ9PFabN6q0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9e1960bc196baf6881340d53dccb203a951745a2",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_6": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1690881714,
+        "narHash": "sha256-h/nXluEqdiQHs1oSgkOOWF+j8gcJMWhwnZ9PFabN6q0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9e1960bc196baf6881340d53dccb203a951745a2",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_7": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1690881714,
+        "narHash": "sha256-h/nXluEqdiQHs1oSgkOOWF+j8gcJMWhwnZ9PFabN6q0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9e1960bc196baf6881340d53dccb203a951745a2",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-regression": {
       "locked": {
         "lastModified": 1643052045,
@@ -715,11 +875,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1681358109,
-        "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
+        "lastModified": 1696261572,
+        "narHash": "sha256-s8TtSYJ1LBpuITXjbPLUPyxzAKw35LhETcajJjCS5f0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "96ba1c52e54e74c3197f4d43026b3f3d92e83ff9",
+        "rev": "0c7ffbc66e6d78c50c38e717ec91a2a14e0622fb",
         "type": "github"
       },
       "original": {
@@ -906,8 +1066,6 @@
     },
     "root": {
       "inputs": {
-        "beam": "beam",
-        "beam-mysql": "beam-mysql",
         "cereal": "cereal",
         "common": "common",
         "euler-events-hs": "euler-events-hs",
@@ -921,28 +1079,57 @@
         ],
         "hedis": "hedis",
         "juspay-extra": "juspay-extra",
-        "mysql-haskell": "mysql-haskell",
         "nixpkgs": [
           "common",
           "nixpkgs"
         ],
-        "sequelize": "sequelize"
+        "sequelize": "sequelize",
+        "servant-mock": "servant-mock",
+        "tinylog": "tinylog"
       }
     },
     "sequelize": {
-      "flake": false,
+      "inputs": {
+        "beam-mysql": "beam-mysql",
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "haskell-flake": [
+          "haskell-flake"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1688647938,
-        "narHash": "sha256-F7nixhDpXNRrpgxRH3xtnN+FkB2HS44VMrnoq1VfBnI=",
+        "lastModified": 1696055637,
+        "narHash": "sha256-RVlpKevWjt9pB9Ia61+ILFcbjB8omiRA6zehmPb6FHg=",
         "owner": "juspay",
         "repo": "haskell-sequelize",
-        "rev": "dc01b0f9e6ba5a51dd8f9d0744a549dc9c0ba244",
+        "rev": "991064c0b9b5f5cf691b19d53ac6b0c9109a2dff",
         "type": "github"
       },
       "original": {
         "owner": "juspay",
+        "ref": "beckn-compatible",
         "repo": "haskell-sequelize",
-        "rev": "dc01b0f9e6ba5a51dd8f9d0744a549dc9c0ba244",
+        "type": "github"
+      }
+    },
+    "servant-mock": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1672315259,
+        "narHash": "sha256-J7Lsa3zI1Z05Gtf5m1x4yRE5vRnuhZLWeUShtrhsPbk=",
+        "owner": "arjunkathuria",
+        "repo": "servant-mock",
+        "rev": "17e90cb831820a30b3215d4f164cf8268607891e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "arjunkathuria",
+        "repo": "servant-mock",
+        "rev": "17e90cb831820a30b3215d4f164cf8268607891e",
         "type": "github"
       }
     },
@@ -961,6 +1148,22 @@
         "type": "github"
       }
     },
+    "tinylog": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1669960992,
+        "narHash": "sha256-o0WEbygbbfIYPonyY6ui1HcbaJcFdngjBhnjWbe65zs=",
+        "rev": "08d3b6066cd2f883e183b7cd01809d1711092d33",
+        "revCount": 78,
+        "type": "git",
+        "url": "https://gitlab.com/arjunkathuria/tinylog.git"
+      },
+      "original": {
+        "rev": "08d3b6066cd2f883e183b7cd01809d1711092d33",
+        "type": "git",
+        "url": "https://gitlab.com/arjunkathuria/tinylog.git"
+      }
+    },
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": "nixpkgs_5"
@@ -976,6 +1179,22 @@
       "original": {
         "owner": "numtide",
         "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "word24": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1647587255,
+        "narHash": "sha256-S37S10sJ45BulvpqJzlhX/J4hY7cW5jLM9nP4xAftac=",
+        "owner": "winterland1989",
+        "repo": "word24",
+        "rev": "445f791e35ddc8098f05879dbcd07c41b115cb39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "winterland1989",
+        "repo": "word24",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,40 +1,43 @@
 {
   inputs = {
     # Common is used only to get the GHC 8.10 package set.
-    common.url = "github:nammayatri/common";
+    # common.url = "github:nammayatri/common";
+
+    # Replace the url with upstream after the GHC 9.2 changes get merged there.
+    common.url = "github:arjunkathuria/common/Mobility-GHC927-rebased-04";
     nixpkgs.follows = "common/nixpkgs";
     flake-parts.follows = "common/flake-parts";
     haskell-flake.follows = "common/haskell-flake";
 
-    # Haskell dependencies
-    cereal.url = "github:juspay/cereal/213f145ccbd99e630ee832d2f5b22894c810d3cc";
+    cereal.url = "github:juspay/cereal";
     cereal.flake = false;
 
     juspay-extra.url = "github:juspay/euler-haskell-common";
-    juspay-extra.inputs.haskell-flake.follows = "common/haskell-flake";
+    juspay-extra.inputs.haskell-flake.follows = "haskell-flake";
 
     euler-events-hs.url = "github:juspay/euler-events-hs/main";
-    euler-events-hs.inputs.haskell-flake.follows = "common/haskell-flake";
+    euler-events-hs.inputs.haskell-flake.follows = "haskell-flake";
 
-    sequelize.url = "github:juspay/haskell-sequelize/dc01b0f9e6ba5a51dd8f9d0744a549dc9c0ba244";
-    sequelize.flake = false;
+    sequelize.url = "github:juspay/haskell-sequelize/beckn-compatible";
+    sequelize.inputs.nixpkgs.follows = "nixpkgs";
+    sequelize.inputs.haskell-flake.follows = "haskell-flake";
+    sequelize.inputs.flake-parts.follows = "flake-parts";
 
-    beam.url = "github:srid/beam/ghc810"; 
-    beam.flake = false;
-
-    beam-mysql.url = "github:juspay/beam-mysql/b4dbc91276f6a8b5356633492f89bdac34ccd9a1";
-    beam-mysql.flake = false;
-
-    mysql-haskell.url = "github:juspay/mysql-haskell/788022d65538db422b02ecc0be138b862d2e5cee"; # https://github.com/winterland1989/mysql-haskell/pull/38
-    mysql-haskell.flake = false;
     hedis.url = "git+https://github.com/juspay/hedis?rev=92a3d5ab73dcb0ea11139a01d6f2950a8b8e7e0e";
     hedis.flake = false;
+
+    servant-mock.url = "github:arjunkathuria/servant-mock?rev=17e90cb831820a30b3215d4f164cf8268607891e";
+    servant-mock.flake = false;
+
+    tinylog.url = "git+https://gitlab.com/arjunkathuria/tinylog.git?rev=08d3b6066cd2f883e183b7cd01809d1711092d33";
+    tinylog.flake = false;
   };
+
   outputs = inputs@{ nixpkgs, flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
       systems = nixpkgs.lib.systems.flakeExposed;
       imports = [
-        inputs.common.flakeModules.ghc810
+        inputs.common.flakeModules.ghc927
         inputs.haskell-flake.flakeModule
       ];
       perSystem = { self', pkgs, lib, config, ... }: {
@@ -44,55 +47,19 @@
           imports = [
             inputs.euler-events-hs.haskellFlakeProjectModules.output
             inputs.juspay-extra.haskellFlakeProjectModules.output
+            inputs.sequelize.haskellFlakeProjectModules.output
           ];
-          basePackages = config.haskellProjects.ghc810.outputs.finalPackages;
+          basePackages = config.haskellProjects.ghc927.outputs.finalPackages;
           packages = {
-            beam-core.source = inputs.beam + /beam-core;
-            beam-migrate.source = inputs.beam + /beam-migrate;
-            beam-mysql.source = inputs.beam-mysql;
-            beam-postgres.source = inputs.beam + /beam-postgres;
-            beam-sqlite.source = inputs.beam + /beam-sqlite;
             hedis.source = inputs.hedis;
-            mysql-haskell.source = inputs.mysql-haskell;
-            sequelize.source = inputs.sequelize;
             cereal.source = inputs.cereal;
+            servant-mock.source = inputs.servant-mock;
+            tinylog.source = inputs.tinylog;
           };
           settings = {
-            beam-core.jailbreak = true;
-            beam-migrate.jailbreak = true;
-            beam-mysql = {
-              check = false;
-              jailbreak = true;
-            };
-            beam-postgres = {
-              check = false;
-              jailbreak = true;
-            };
-            beam-sqlite = {
-              check = false;
-              jailbreak = true;
-            };
+            bytestring-conversion.broken = false;
             hedis.check = false;
-            mysql-haskell = {
-              check = false;
-              jailbreak = true;
-            };
             sequelize.check = false;
-            cereal = {
-              check = false;
-              jailbreak = true;
-            };
-            euler-events-hs = {
-              check = false;
-              jailbreak = true;
-            };
-            juspay-extra = {
-              check = false;
-              jailbreak = true;
-            };
-            nonempty-containers = {
-              jailbreak = true;
-            };
             servant-client = {
               jailbreak = true;
             };
@@ -102,7 +69,15 @@
             servant-server = {
               jailbreak = true;
             };
+            servant-mock = {
+              check = false;
+              jailbreak = true;
+            };
+            servant = {
+              jailbreak = true;
+            };
           };
+          autoWire = [ "packages" "checks" "devShells" "apps"];
         };
       };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -1,10 +1,8 @@
 {
   inputs = {
-    # Common is used only to get the GHC 8.10 package set.
-    # common.url = "github:nammayatri/common";
+    # Common is used only to get the GHC 9.2 package set.
+    common.url = "github:nammayatri/common";
 
-    # Replace the url with upstream after the GHC 9.2 changes get merged there.
-    common.url = "github:arjunkathuria/common/Mobility-GHC927-rebased-04";
     nixpkgs.follows = "common/nixpkgs";
     flake-parts.follows = "common/flake-parts";
     haskell-flake.follows = "common/haskell-flake";

--- a/src/EulerHS/Extra/EulerDB.hs
+++ b/src/EulerHS/Extra/EulerDB.hs
@@ -23,7 +23,7 @@ module EulerHS.Extra.EulerDB (
 
 import           EulerHS.Language (MonadFlow, SqlDB, getOption, logErrorT,
                                    throwException, withDB, withDBTransaction)
-import           EulerHS.Prelude hiding (getOption)
+import           EulerHS.Prelude
 import           EulerHS.Types (DBConfig, OptionEntity)
 
 import           Database.Beam.MySQL (MySQLM)

--- a/src/EulerHS/Extra/Monitoring/Flow.hs
+++ b/src/EulerHS/Extra/Monitoring/Flow.hs
@@ -23,10 +23,10 @@ import           EulerHS.Options (OptionEntity, mkOptionKey)
 import           Euler.Events.MetricApi.MetricApi
 
 isLatencyMetricEnabled :: Bool
-isLatencyMetricEnabled = fromMaybe False $ readMaybe =<< Conf.lookupEnvT "LATENCY_METRIC_ENABLED"
+isLatencyMetricEnabled = fromMaybe False $ readMaybe =<< Conf.lookupEnvT @String "LATENCY_METRIC_ENABLED"
 
 isLatencyPromMetricEnabled :: Bool
-isLatencyPromMetricEnabled = fromMaybe False $ readMaybe =<< Conf.lookupEnvT "LATENCY_PROM_METRIC_ENABLED"
+isLatencyPromMetricEnabled = fromMaybe False $ readMaybe =<< Conf.lookupEnvT @String "LATENCY_PROM_METRIC_ENABLED"
 
 getCurrentDateInMillisIO :: IO Double
 getCurrentDateInMillisIO = do

--- a/src/EulerHS/Framework/Language.hs
+++ b/src/EulerHS/Framework/Language.hs
@@ -102,7 +102,7 @@ import           EulerHS.Logger.Language (Logger, masterLogger)
 import           EulerHS.Logger.Types (LogLevel (Debug, Error, Info, Warning),
                                        Message (Message), ExceptionEntry(..))
 import           EulerHS.Options (OptionEntity, mkOptionKey)
-import           EulerHS.Prelude hiding (getOption, throwM)
+import           EulerHS.Prelude hiding (throwM)
 import qualified EulerHS.PubSub.Language as PSL
 import           EulerHS.SqlDB.Language (SqlDB)
 import           EulerHS.SqlDB.Types (BeamRunner, BeamRuntime, DBConfig,

--- a/src/EulerHS/Framework/Language.hs
+++ b/src/EulerHS/Framework/Language.hs
@@ -1903,7 +1903,7 @@ instance OptionEntity DBMetricCfg DBAndRedisMetricHandler
 ---------------------------------------------------------
 
 isDBMetricEnabled :: Bool
-isDBMetricEnabled = fromMaybe False $ readMaybe =<< Conf.lookupEnvT "DB_METRIC_ENABLED"
+isDBMetricEnabled = fromMaybe False $ readMaybe =<< (Conf.lookupEnvT "DB_METRIC_ENABLED" :: Maybe Text)
 
 ---------------------------------------------------------
 

--- a/src/EulerHS/Framework/Runtime.hs
+++ b/src/EulerHS/Framework/Runtime.hs
@@ -85,10 +85,10 @@ data ConfigEntry =   ConfigEntry
 deriving instance Show ConfigEntry
 
 configCacheSize :: Integer
-configCacheSize = 
+configCacheSize =
   let
     mbSize :: Maybe Integer
-    mbSize = readMaybe =<< lookupEnvT "CONFIG_CACHE_SIZE"
+    mbSize = readMaybe =<< lookupEnvT @String "CONFIG_CACHE_SIZE"
 
   in fromMaybe 4096 mbSize
 

--- a/src/EulerHS/HttpAPI.hs
+++ b/src/EulerHS/HttpAPI.hs
@@ -218,9 +218,9 @@ buildSettings HTTPClientSettings{..} =
 
     mkP12Cert pfx passPhrase = do
       pkcs12Cert <- mapLeftShow $ PKCS12.readP12FileFromMemory pfx
-      cert <- mapLeftShow $ PKCS12.recover passPhrase pkcs12Cert
+      cert <- mapLeftShow $ (snd <$> PKCS12.recoverAuthenticated  passPhrase pkcs12Cert)
       let pkcs12Creds = PKCS12.toCredential cert
-      maybeCreds <- mapLeftShow $ PKCS12.recover passPhrase pkcs12Creds
+      maybeCreds <- mapLeftShow $ PKCS12.recover (PKCS12.toProtectionPassword passPhrase) pkcs12Creds
       maybe (Left "Invalid P12 certificate") Right maybeCreds
 
     mapLeftShow = Extra.mapLeft show

--- a/src/EulerHS/KVConnector/Flow.hs
+++ b/src/EulerHS/KVConnector/Flow.hs
@@ -38,6 +38,7 @@ import           Control.Arrow ((>>>))
 import qualified Data.Aeson as A
 import qualified Data.ByteString.Lazy as BSL
 import           Data.List (span, maximum)
+import           Data.Maybe (listToMaybe)
 import qualified Data.Text as T
 import qualified EulerHS.Language as L
 import qualified Data.HashMap.Strict as HM

--- a/src/EulerHS/KVConnector/Flow.hs
+++ b/src/EulerHS/KVConnector/Flow.hs
@@ -25,10 +25,9 @@ module EulerHS.KVConnector.Flow
   )
  where
 
-import           EulerHS.Extra.Time (getCurrentDateInMillis)
 import           EulerHS.Prelude hiding (maximum)
 import           EulerHS.CachedSqlDBQuery (runQuery)
-import           EulerHS.KVConnector.Types (KVConnector(..), MeshConfig, MeshResult, MeshError(..), MeshMeta(..), SecondaryKey(..), tableName, keyMap, Source(..), Operation(..))
+import           EulerHS.KVConnector.Types (KVConnector(..), MeshConfig, MeshResult, MeshError(..), MeshMeta(..), SecondaryKey(..), tableName, keyMap, Source(..))
 import           EulerHS.KVConnector.DBSync (getCreateQuery, getUpdateQuery, getDeleteQuery, getDbDeleteCommandJson, getDbUpdateCommandJson, getDbUpdateCommandJsonWithPrimaryKey, getDbDeleteCommandJsonWithPrimaryKey, DBCommandVersion(..))
 import           EulerHS.KVConnector.InMemConfig.Flow (searchInMemoryCache, pushToInMemConfigStream, fetchRowFromDBAndAlterImc)
 import           EulerHS.KVConnector.InMemConfig.Types (ImcStreamCommand(..))
@@ -37,14 +36,14 @@ import           EulerHS.KVDB.Types (KVDBReply)
 import           Control.Arrow ((>>>))
 import qualified Data.Aeson as A
 import qualified Data.ByteString.Lazy as BSL
-import           Data.List (span, maximum)
+import           Data.List (maximum)
 import           Data.Maybe (listToMaybe)
 import qualified Data.Text as T
 import qualified EulerHS.Language as L
 import qualified Data.HashMap.Strict as HM
 import           EulerHS.SqlDB.Types (BeamRunner, BeamRuntime, DBConfig, DBError)
 import qualified EulerHS.SqlDB.Language as DB
-import           Sequelize (fromColumnar', columnize, sqlSelect, sqlSelect', sqlUpdate, sqlDelete, modelTableName, Model, Where, Clause(..), Set(..), OrderBy(..))
+import           Sequelize (fromColumnar', columnize, sqlSelect, sqlSelect', sqlUpdate, sqlDelete, Model, Where, Clause(..), Set(..), OrderBy(..))
 import           EulerHS.CachedSqlDBQuery (findAllSql, createReturning, createSqlWoReturing, updateOneSqlWoReturning, SqlReturning(..))
 import qualified Database.Beam as B
 import qualified Database.Beam.Postgres as BP
@@ -52,7 +51,6 @@ import           Data.Either.Extra (mapRight, mapLeft)
 import           Named (defaults, (!))
 import qualified Data.Serialize as Serialize
 import qualified EulerHS.KVConnector.Encoding as Encoding
-import           System.CPUTime (getCPUTime)
 import qualified Data.Maybe as DMaybe
 
 createWoReturingKVConnector :: forall (table :: (Type -> Type) -> Type) be m beM.

--- a/src/EulerHS/KVConnector/Metrics.hs
+++ b/src/EulerHS/KVConnector/Metrics.hs
@@ -98,7 +98,7 @@ instance OptionEntity KVMetricCfg KVMetricHandler
 ---------------------------------------------------------
 
 isKVMetricEnabled :: Bool
-isKVMetricEnabled = fromMaybe True $ readMaybe =<< Conf.lookupEnvT "KV_METRIC_ENABLED"
+isKVMetricEnabled = fromMaybe True $ readMaybe =<< Conf.lookupEnvT @String "KV_METRIC_ENABLED"
 
 ---------------------------------------------------------
 

--- a/src/EulerHS/KVConnector/Utils.hs
+++ b/src/EulerHS/KVConnector/Utils.hs
@@ -299,16 +299,16 @@ getConfigStreamBasename :: Text
 getConfigStreamBasename = fromMaybe "ConfigStream" $ lookupEnvT "CONFIG_STREAM_BASE_NAME"
 
 getConfigStreamMaxShards :: Int
-getConfigStreamMaxShards = fromMaybe 20 $ readMaybe =<< lookupEnvT "CONFIG_STREAM_MAX_SHARDS"
+getConfigStreamMaxShards = fromMaybe 20 $ readMaybe =<< lookupEnvT @String "CONFIG_STREAM_MAX_SHARDS"
 
 getConfigStreamLooperDelayInSec :: Int
-getConfigStreamLooperDelayInSec = fromMaybe 5 $ readMaybe =<< lookupEnvT "CONFIG_STREAM_LOOPER_DELAY_IN_SEC"
+getConfigStreamLooperDelayInSec = fromMaybe 5 $ readMaybe =<< lookupEnvT @String "CONFIG_STREAM_LOOPER_DELAY_IN_SEC"
 
 getConfigEntryTtlJitterInSeconds :: Int
-getConfigEntryTtlJitterInSeconds = fromMaybe 5 $ readMaybe =<< lookupEnvT "CONFIG_STREAM_TTL_JITTER_IN_SEC"
+getConfigEntryTtlJitterInSeconds = fromMaybe 5 $ readMaybe =<< lookupEnvT @String "CONFIG_STREAM_TTL_JITTER_IN_SEC"
 
 getConfigEntryBaseTtlInSeconds :: Int
-getConfigEntryBaseTtlInSeconds = fromMaybe 10 $ readMaybe =<< lookupEnvT "CONFIG_STREAM_BASE_TTL_IN_SEC"
+getConfigEntryBaseTtlInSeconds = fromMaybe 10 $ readMaybe =<< lookupEnvT @String "CONFIG_STREAM_BASE_TTL_IN_SEC"
 
 getConfigEntryNewTtl :: (L.MonadFlow m) => m LocalTime
 getConfigEntryNewTtl = do
@@ -466,19 +466,19 @@ whereClauseDiffCheck whereClause =
         _ -> checkForPrimaryOrSecondary keyHashMap xs
 
 isWhereClauseDiffCheckEnabled :: Bool
-isWhereClauseDiffCheckEnabled = fromMaybe True $ readMaybe =<< lookupEnvT "IS_WHERE_CLAUSE_DIFF_CHECK_ENABLED"
+isWhereClauseDiffCheckEnabled = fromMaybe True $ readMaybe =<< lookupEnvT @String "IS_WHERE_CLAUSE_DIFF_CHECK_ENABLED"
 
 isRecachingEnabled :: Bool
-isRecachingEnabled = fromMaybe False $ readMaybe =<< lookupEnvT "IS_RECACHING_ENABLED"
+isRecachingEnabled = fromMaybe False $ readMaybe =<< lookupEnvT @String "IS_RECACHING_ENABLED"
 
 shouldLogFindDBCallLogs :: Bool
-shouldLogFindDBCallLogs = fromMaybe False $ readMaybe =<< lookupEnvT "IS_FIND_DB_LOGS_ENABLED"
+shouldLogFindDBCallLogs = fromMaybe False $ readMaybe =<< lookupEnvT @String "IS_FIND_DB_LOGS_ENABLED"
 
 isLogsEnabledForModel :: Text -> Bool
 isLogsEnabledForModel modelName = do
   let env :: Text = fromMaybe "development" $ lookupEnvT "NODE_ENV"
   if env == "production" then do
-    let enableModelList = fromMaybe [] $ readMaybe =<< lookupEnvT "IS_LOGS_ENABLED_FOR_MODEL"
+    let enableModelList = fromMaybe [] $ readMaybe =<< lookupEnvT @String "IS_LOGS_ENABLED_FOR_MODEL"
     modelName `elem` enableModelList
     else True
 

--- a/src/EulerHS/KVConnector/Utils.hs
+++ b/src/EulerHS/KVConnector/Utils.hs
@@ -162,7 +162,7 @@ getPKeyAndValueList table = do
       keyValueList = sortBy (compare `on` fst) k
       rowObject = A.toJSON table
   case rowObject of
-    A.Object hm -> DL.foldl' (\acc x -> [go hm x] <> acc) [] keyValueList
+    A.Object hm -> DL.foldl' (\acc x -> (go hm x) : acc) [] keyValueList
     _ -> error "Cannot work on row that isn't an Object"
 
   where 

--- a/src/EulerHS/KVDB/Types.hs
+++ b/src/EulerHS/KVDB/Types.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE RecordWildCards    #-}
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# OPTIONS_GHC -Wwarn=missing-fields #-}
 
 module EulerHS.KVDB.Types
   (

--- a/src/EulerHS/Masking.hs
+++ b/src/EulerHS/Masking.hs
@@ -9,6 +9,9 @@ import qualified Data.Aeson as Aeson
 import qualified Data.CaseInsensitive as CI
 import qualified Data.HashMap.Strict as HashMap
 import qualified Data.HashSet as HS
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Aeson.Key as AesonKey
+import qualified Data.Bifunctor as Bifunctor
 import qualified Data.List as List
 import qualified Data.Map as Map
 import qualified Data.Text as Text
@@ -80,7 +83,7 @@ handleObject shouldMask maskText mbContentType = HashMap.mapWithKey maskingFn
     maskingFn key value = bool (maskJSON shouldMask maskText mbContentType value) (Aeson.String maskText) $ shouldMask key
 
 handleQueryString :: ByteString -> Aeson.Value
-handleQueryString strg = Aeson.Object . fmap (Aeson.String . fromMaybe "") . HashMap.fromList $ HTTP.parseQueryText strg
+handleQueryString strg = Aeson.Object . fmap (Aeson.String . fromMaybe "") . KeyMap.fromList . map (Bifunctor.first AesonKey.fromText) $ HTTP.parseQueryText strg
 
 notSupportedPlaceHolder :: Maybe ByteString -> Aeson.Value
 notSupportedPlaceHolder (Just bs) = Aeson.String $ "Logging Not Support For this content " <> decodeUtf8 bs

--- a/src/EulerHS/Masking.hs
+++ b/src/EulerHS/Masking.hs
@@ -6,8 +6,9 @@ import           Data.HashSet (member)
 import           EulerHS.Prelude
 import Data.String.Conversions hiding ((<>))
 import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as AKM
+import qualified Data.Aeson.Key as AKey
 import qualified Data.CaseInsensitive as CI
-import qualified Data.HashMap.Strict as HashMap
 import qualified Data.HashSet as HS
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.Aeson.Key as AesonKey
@@ -78,9 +79,9 @@ maskJSON shouldMask maskText mbContentType (Aeson.String r) =
 maskJSON _ _ _ value = value
 
 handleObject :: (Text -> Bool) -> Text -> Maybe ByteString -> Aeson.Object -> Aeson.Object
-handleObject shouldMask maskText mbContentType = HashMap.mapWithKey maskingFn
+handleObject shouldMask maskText mbContentType = AKM.mapWithKey maskingFn
   where
-    maskingFn key value = bool (maskJSON shouldMask maskText mbContentType value) (Aeson.String maskText) $ shouldMask key
+    maskingFn key value = bool (maskJSON shouldMask maskText mbContentType value) (Aeson.String maskText) $ shouldMask (AKey.toText key)
 
 handleQueryString :: ByteString -> Aeson.Value
 handleQueryString strg = Aeson.Object . fmap (Aeson.String . fromMaybe "") . KeyMap.fromList . map (Bifunctor.first AesonKey.fromText) $ HTTP.parseQueryText strg

--- a/src/EulerHS/Prelude.hs
+++ b/src/EulerHS/Prelude.hs
@@ -33,7 +33,7 @@ import           Data.Serialize as X (Serialize)
 import           Fmt as X ((+|), (+||), (|+), (||+))
 import           GHC.Base as X (until)
 import           Universum (catchAny)
-import           Universum as X hiding (All, Option, Set, Type, catchAny, head,
+import           Universum as X hiding (All, Set, Type, catchAny, head,
                                  init, last, set, tail, trace)
 
 -- Lift for Church encoded Free

--- a/src/EulerHS/SqlDB/Types.hs
+++ b/src/EulerHS/SqlDB/Types.hs
@@ -127,12 +127,12 @@ class BeamRunner beM where
 
 instance BeamRunner BS.SqliteM where
   getBeamDebugRunner (NativeSQLiteConn conn) beM =
-    \logger -> SQLite.runBeamSqliteDebug (logger . T.pack) conn beM
+    \logger -> SQLite.runBeamSqliteDebug (logger) conn beM
   getBeamDebugRunner _ _ = \_ -> error "Not a SQLite connection"
 
 instance BeamRunner BP.Pg where
   getBeamDebugRunner (NativePGConn conn) beM =
-    \logger -> BP.runBeamPostgresDebug (logger . T.pack) conn beM
+    \logger -> BP.runBeamPostgresDebug (logger) conn beM
   getBeamDebugRunner _ _ = \_ -> error "Not a Postgres connection"
 
 instance BeamRunner BM.MySQLM where

--- a/src/EulerHS/SqlDB/Types.hs
+++ b/src/EulerHS/SqlDB/Types.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE RecordWildCards        #-}
 {-# LANGUAGE ScopedTypeVariables    #-}
 {-# LANGUAGE DeriveDataTypeable     #-}
+{-# OPTIONS_GHC -Wwarn=incomplete-patterns #-}
 
 module EulerHS.SqlDB.Types
   (

--- a/src/EulerHS/SqlDB/Types.hs
+++ b/src/EulerHS/SqlDB/Types.hs
@@ -155,7 +155,6 @@ data NativeSqlPool
   = NativePGPool (DP.Pool BP.Connection)         -- ^ 'Pool' with Postgres connections
   | NativeMySQLPool (DP.Pool MySQL.MySQLConn)   -- ^ 'Pool' with MySQL connections
   | NativeSQLitePool (DP.Pool SQLite.Connection) -- ^ 'Pool' with SQLite connections
-  deriving stock (Show)
 
 -- | Representation of native DB connections that we use in implementation.
 data NativeSqlConn

--- a/src/EulerHS/SqlDB/Types.hs
+++ b/src/EulerHS/SqlDB/Types.hs
@@ -61,7 +61,6 @@ import qualified Database.Beam.Sqlite.Connection as SQLite
 import qualified Database.MySQL.Base as MySQL
 import qualified Database.PostgreSQL.Simple as PGS
 import qualified Database.SQLite.Simple as SQLite
-import qualified Data.Text as T
 import           EulerHS.Prelude
 import           EulerHS.SqlDB.MySQL (MySQLConfig (..), createMySQLConn)
 import           EulerHS.SqlDB.Postgres (PostgresConfig (..),
@@ -127,7 +126,7 @@ class BeamRunner beM where
 
 instance BeamRunner BS.SqliteM where
   getBeamDebugRunner (NativeSQLiteConn conn) beM =
-    \logger -> SQLite.runBeamSqliteDebug (logger) conn beM
+    \logger -> SQLite.runBeamSqliteDebug logger conn beM
   getBeamDebugRunner _ _ = \_ -> error "Not a SQLite connection"
 
 instance BeamRunner BP.Pg where

--- a/src/EulerHS/SqlDB/Types.hs
+++ b/src/EulerHS/SqlDB/Types.hs
@@ -60,6 +60,7 @@ import qualified Database.Beam.Sqlite.Connection as SQLite
 import qualified Database.MySQL.Base as MySQL
 import qualified Database.PostgreSQL.Simple as PGS
 import qualified Database.SQLite.Simple as SQLite
+import qualified Data.Text as T
 import           EulerHS.Prelude
 import           EulerHS.SqlDB.MySQL (MySQLConfig (..), createMySQLConn)
 import           EulerHS.SqlDB.Postgres (PostgresConfig (..),
@@ -125,12 +126,12 @@ class BeamRunner beM where
 
 instance BeamRunner BS.SqliteM where
   getBeamDebugRunner (NativeSQLiteConn conn) beM =
-    \logger -> SQLite.runBeamSqliteDebug logger conn beM
+    \logger -> SQLite.runBeamSqliteDebug (logger . T.pack) conn beM
   getBeamDebugRunner _ _ = \_ -> error "Not a SQLite connection"
 
 instance BeamRunner BP.Pg where
   getBeamDebugRunner (NativePGConn conn) beM =
-    \logger -> BP.runBeamPostgresDebug logger conn beM
+    \logger -> BP.runBeamPostgresDebug (logger . T.pack) conn beM
   getBeamDebugRunner _ _ = \_ -> error "Not a Postgres connection"
 
 instance BeamRunner BM.MySQLM where

--- a/test/extra/Options.hs
+++ b/test/extra/Options.hs
@@ -196,7 +196,7 @@ fruit :: Plant
 fruit = Fruit $ Apple 12 (Just "green")
 
 enc_plant :: BSL.ByteString
-enc_plant = "{\"tag\":\"Fruit\",\"contents\":{\"weight\":12,\"colour\":\"green\"}}"
+enc_plant = "{\"contents\":{\"colour\":\"green\",\"weight\":12},\"tag\":\"Fruit\"}"
 
 data PlantUnTag
   = FruitU Apple
@@ -212,7 +212,7 @@ berry :: PlantUnTag
 berry = BerryU $ Strawberry 2 (Just "red")
 
 enc_plantUntag :: BSL.ByteString
-enc_plantUntag = "{\"weight\":2,\"colour\":\"red\"}"
+enc_plantUntag = "{\"colour\":\"red\",\"weight\":2}"
 
 -------------------------------------------------------------------------------
 -- stripLensPrefixOptions
@@ -229,7 +229,7 @@ cat :: Cat
 cat = Cat "Kita" (Just "grey")
 
 enc_cat :: BSL.ByteString
-enc_cat = "{\"cName\":\"Kita\",\"cColour\":\"grey\"}"
+enc_cat = "{\"cColour\":\"grey\",\"cName\":\"Kita\"}"
 
 data Dog = Dog
   { cName :: Text
@@ -280,7 +280,7 @@ cow :: Cow
 cow = Cow "Mu" (Just "white-nd-black")
 
 enc_cow :: BSL.ByteString
-enc_cow = "{\"cName\":\"Mu\",\"cColour\":\"white-nd-black\"}"
+enc_cow = "{\"cColour\":\"white-nd-black\",\"cName\":\"Mu\"}"
 
 data Wolf = Wolf
   { cName :: Text

--- a/test/language/DBSetup.hs
+++ b/test/language/DBSetup.hs
@@ -19,14 +19,14 @@ import           Sequelize
 -- Prepare custom types for tests
 
 data UserT f = User
-    { _userGUID  :: B.C f Int
+    { _userGUID  :: B.C f Int64
     , _firstName :: B.C f Text
     , _lastName  :: B.C f Text
     } deriving (Generic, B.Beamable)
 
 instance B.Table UserT where
   data PrimaryKey UserT f =
-    UserId (B.C f Int) deriving (Generic, B.Beamable)
+    UserId (B.C f Int64) deriving (Generic, B.Beamable)
   primaryKey = UserId . _userGUID
 
 instance ModelMeta UserT where

--- a/test/language/FlowSpec.hs
+++ b/test/language/FlowSpec.hs
@@ -21,7 +21,7 @@ import           Test.Hspec (Spec, around, around_, describe, it, shouldBe,
 
 import           EulerHS.Interpreters (runFlow)
 import           EulerHS.Language as L
-import           EulerHS.Prelude hiding (get, getOption)
+import           EulerHS.Prelude hiding (get)
 import           EulerHS.Runtime (createLoggerRuntime, withFlowRuntime)
 import           EulerHS.TestData.Types (NTTestKeyWithIntPayload (NTTestKeyWithIntPayload),
                                          NTTestKeyWithIntPayloadAnotherEnc (NTTestKeyWithIntPayloadAnotherEnc),

--- a/test/language/HttpAPISpec.hs
+++ b/test/language/HttpAPISpec.hs
@@ -4,7 +4,7 @@ module HttpAPISpec (spec) where
 
 --import           EulerHS.Interpreters (runFlow)
 --import           EulerHS.Language
-import           EulerHS.Prelude hiding (get, getOption)
+import           EulerHS.Prelude hiding (get)
 --import           EulerHS.Runtime (createLoggerRuntime, withFlowRuntime)
 import           Test.Hspec (Spec, describe, it, shouldBe)
 import qualified EulerHS.Types as T

--- a/test/language/Scenario1.hs
+++ b/test/language/Scenario1.hs
@@ -8,7 +8,7 @@ module Scenario1
 import           Client (User (User), getUser, port, userGUID)
 import           Data.Text (pack)
 import           EulerHS.Language
-import           EulerHS.Prelude hiding (getOption, pack)
+import           EulerHS.Prelude hiding (pack)
 import           EulerHS.TestData.Types
 import           Servant.Client (BaseUrl (..), Scheme (..))
 

--- a/testDB/SQLDB/TestData/Scenarios/MySQL.hs
+++ b/testDB/SQLDB/TestData/Scenarios/MySQL.hs
@@ -109,7 +109,7 @@ selectUnknownDbScript dbcfg = do
           $ B.filter_ predicate
           $ B.all_ (_users eulerDb)
 
-selectRowDbScript :: Int -> T.DBConfig BM.MySQLM -> L.Flow (T.DBResult (Maybe User))
+selectRowDbScript :: Int64 -> T.DBConfig BM.MySQLM -> L.Flow (T.DBResult (Maybe User))
 selectRowDbScript userId dbcfg = do
     econn <- L.getSqlDBConnection dbcfg
 

--- a/testDB/SQLDB/TestData/Types.hs
+++ b/testDB/SQLDB/TestData/Types.hs
@@ -13,14 +13,14 @@ import qualified EulerHS.Types as T
 -- sqlite3 db
 -- CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, first_name VARCHAR NOT NULL, last_name VARCHAR NOT NULL);
 data UserT f = User
-    { _userId        :: B.C f Int
+    { _userId        :: B.C f Int64
     , _userFirstName :: B.C f Text
     , _userLastName  :: B.C f Text
     } deriving (Generic, B.Beamable)
 
 instance B.Table UserT where
   data PrimaryKey UserT f =
-    UserId (B.C f Int) deriving (Generic, B.Beamable)
+    UserId (B.C f Int64) deriving (Generic, B.Beamable)
   primaryKey = UserId . _userId
 
 type User = UserT Identity
@@ -43,7 +43,7 @@ eulerDb = B.defaultDbSettings
 
 data SqliteSequenceT f = SqliteSequence
     { _name :: B.C f Text
-    , _seq  :: B.C f Int
+    , _seq  :: B.C f Int64
     } deriving (Generic, B.Beamable)
 
 instance B.Table SqliteSequenceT where
@@ -73,7 +73,7 @@ susers =
 mkUser ::
   (BeamSqlBackend be,
     B.SqlValable (B.Columnar f Text),
-    B.Columnar f Int ~ B.QGenExpr ctxt be s a,
+    B.Columnar f Int64 ~ B.QGenExpr ctxt be s a,
     B.HaskellLiteralForQExpr (B.Columnar f Text) ~ Text) =>
     SimpleUser ->
     UserT f

--- a/testDB/SQLDB/Tests/QueryExamplesSpec.hs
+++ b/testDB/SQLDB/Tests/QueryExamplesSpec.hs
@@ -66,19 +66,19 @@ td3 = TimeOfDay
   }
 
 data MemberT f = Member
-    { memberId      :: B.C f Int
+    { memberId      :: B.C f Int64
     , surName       :: B.C f Text
     , firstName     :: B.C f Text
     , address       :: B.C f Text
-    , zipCode       :: B.C f Int
+    , zipCode       :: B.C f Int64
     , telephone     :: B.C f Text
-    , recommendedBy :: B.C f (Maybe Int)
+    , recommendedBy :: B.C f (Maybe Int64)
     , joinDate      :: B.C f LocalTime
     } deriving (Generic, B.Beamable)
 
 instance B.Table MemberT where
   data PrimaryKey MemberT f =
-    MemberId (B.C f Int) deriving (Generic, B.Beamable)
+    MemberId (B.C f Int64) deriving (Generic, B.Beamable)
   primaryKey = MemberId . memberId
 
 type Member = MemberT Identity
@@ -111,7 +111,7 @@ membersEMod = B.modifyTableFields
     }
 
 data FacilityT f = Facility
-    { facilityId         :: B.C f Int
+    { facilityId         :: B.C f Int64
     , name               :: B.C f Text
     , memberCost         :: B.C f Double
     , guestCost          :: B.C f Double
@@ -121,7 +121,7 @@ data FacilityT f = Facility
 
 instance B.Table FacilityT where
   data PrimaryKey FacilityT f =
-    FacrId (B.C f Int) deriving (Generic, B.Beamable)
+    FacrId (B.C f Int64) deriving (Generic, B.Beamable)
   primaryKey = FacrId . facilityId
 
 type Facility = FacilityT Identity

--- a/testDB/SQLDB/Tests/QueryExamplesSpec.hs
+++ b/testDB/SQLDB/Tests/QueryExamplesSpec.hs
@@ -11,7 +11,7 @@ import           Database.Beam.Sqlite (SqliteM)
 import           EulerHS.Interpreters
 import           EulerHS.Language
 import qualified EulerHS.Language as L
-import           EulerHS.Prelude hiding (getOption)
+import           EulerHS.Prelude
 import           EulerHS.Runtime (withFlowRuntime)
 import qualified EulerHS.Runtime as R
 import           EulerHS.Types (_isAsync, _logFilePath, _logToFile,


### PR DESCRIPTION
This PR includes all the required changes to make this project upgrade to and build with GHC 9.2.7 and related tooling.

Changes include but not limited to:-

0. Use updated upstream repos like "nammayatri/common" etc.
1. Use updated juspay dependencies (which were in-turn patched to be able to build with GHC 9.2.7) like sequelize, hedis etc.
2. Code changes and refactoring needed to build after breaking changes across major library version upgrades for eg. aeson 1.x -> aeson 2.x and others (servant etc.).
3. Updated Nix flake build setup.
4. Patched tests code to be able to build with GHC 9.2.7 updated libraries and packages.
5. Adds some basic QOL improvements like an envrc file to make it work with direnv, updated gitignore, new cabal.project file etc.

