### PR TITLE
Backend/feat/redis-cluster-pipelining

### DIFF
--- a/euler-hs.cabal
+++ b/euler-hs.cabal
@@ -77,6 +77,7 @@ library
     EulerHS.Logger.Types
     EulerHS.KVConnector.InMemConfig.Types
     EulerHS.KVConnector.Utils
+    EulerHS.KVConnector.Helper.Utils
     EulerHS.Extra.Regex
     EulerHS.Masking
     EulerHS.Extra.URLSanitization

--- a/src/EulerHS/KVConnector/Helper/Utils.hs
+++ b/src/EulerHS/KVConnector/Helper/Utils.hs
@@ -1,0 +1,9 @@
+module EulerHS.KVConnector.Helper.Utils where
+
+import           Data.Time.Clock(getCurrentTime, NominalDiffTime, UTCTime, diffUTCTime)
+import EulerHS.Prelude
+
+latency :: UTCTime -> IO NominalDiffTime
+latency time = do
+  currentTime <- getCurrentTime
+  return $ diffUTCTime currentTime time

--- a/src/EulerHS/KVDB/Interpreter.hs
+++ b/src/EulerHS/KVDB/Interpreter.hs
@@ -45,6 +45,13 @@ interpretKeyValueF runRedis (L.Get k next) =
   fmap next $
     runRedis $ R.get k
 
+interpretKeyValueF runRedis (L.MGet k next) =
+  fmap next $
+    runRedis $ R.mget k
+
+interpretKeyValueF runRedis (L.MSet k next) =
+  next . second fromRdStatus <$> runRedis (R.mset k)
+
 interpretKeyValueF runRedis (L.Exists k next) =
   fmap next $
     runRedis $ R.exists k
@@ -207,6 +214,12 @@ interpretKeyValueTxF (L.SetOpts k v ttl cond next) =
 
 interpretKeyValueTxF (L.Get k next) =
   next <$> R.get k
+
+interpretKeyValueTxF (L.MGet k next) =
+  next <$> R.mget k
+
+interpretKeyValueTxF (L.MSet k next) =
+  next . fmap fromRdStatus <$> R.mset k
 
 interpretKeyValueTxF (L.Exists k next) =
   next <$> R.exists k


### PR DESCRIPTION
Added an alternate function for  `getDataFromPKeysRedis`  which can be directly switched with a env variable. 
This function uses redis pipelining based on grouping all keys which belongs to same slot and doing ` mget` on all keys belonging to same slot. Similarly added function `mget` and `sget`.